### PR TITLE
Load from JSON and ability to return multiple matches

### DIFF
--- a/Sources/SwiftRuleEngine/RuleEngine.swift
+++ b/Sources/SwiftRuleEngine/RuleEngine.swift
@@ -17,14 +17,14 @@ enum RuleEngineError: Error {
 final public class RuleEngine {
     private var rules: [Rule] = []
     private let ruleDecoder: RuleDecoder
-
-
+    
+    
     //Used when we will add additional rules later
     public convenience init(customOperators: [Operator.Type] = []) throws {
         let rules: [Rule] = []
         try self.init(rules: rules, customOperators: customOperators)
     }
-        
+    
     public convenience init(rules: [String], customOperators: [Operator.Type] = []) throws {
         let ruleDecoder = try RuleDecoder(customOperators)
         let decodedRules = rules.compactMap { dictRule -> Rule? in
@@ -33,7 +33,7 @@ final public class RuleEngine {
         }
         try self.init(rules: decodedRules, customOperators: customOperators)
     }
-
+    
     public convenience init(rules: [[String: Any]], customOperators: [Operator.Type] = []) throws {
         let ruleDecoder = try RuleDecoder(customOperators)
         let decodedRules = rules.compactMap { dictRule -> Rule? in
@@ -42,7 +42,7 @@ final public class RuleEngine {
         }
         try self.init(rules: decodedRules, customOperators: customOperators)
     }
-
+    
     public init(rules: [Rule], customOperators: [Operator.Type] = []) throws {
         self.ruleDecoder = try RuleDecoder(customOperators)
         self.rules = rules
@@ -55,29 +55,29 @@ final public class RuleEngine {
             self.rules.sort { $0.priority > $1.priority }
         }
     }
-
+    
     private func decodeRule(rule: [String: Any]) throws -> Rule {
         guard let ruleData = try? JSONSerialization.data(withJSONObject: rule, options: []) else {
             throw RuleEngineError.invalidRule("Error converting dict to data")
         }
-
+        
         guard let rule = try? ruleDecoder.decode(Rule.self, from: ruleData) else {
             throw RuleEngineError.invalidRule("Error decoding rule")
         }
         return rule
     }
-
+    
     private func decodeRule(rule: String) throws -> Rule {
         guard let ruleData = rule.data(using: .utf8) else {
             throw RuleEngineError.invalidRule("Rule not in utf8 format")
         }
-
+        
         guard let rule = try? ruleDecoder.decode(Rule.self, from: ruleData) else {
             throw RuleEngineError.invalidRule("Error decoding rule")
         }
         return rule
     }
-
+    
     public func evaluate(_ obj: Any) -> Rule? {
         for rule in rules {
             var rule = rule
@@ -90,19 +90,19 @@ final public class RuleEngine {
         }
         return nil
     }
-
+    
     public func evaluateAllRules(_ obj: Any) -> [Rule] {
-            var returnMatches: [Rule] = []
-
-            for rule in rules {
-                var rule = rule
-                guard ((try? rule.conditions.evaluate(obj)) != nil) else {
-                    continue
-                }
-                if rule.conditions.match {
-                    returnMatches.append(rule)
-                }
+        var returnMatches: [Rule] = []
+        
+        for rule in rules {
+            var rule = rule
+            guard ((try? rule.conditions.evaluate(obj)) != nil) else {
+                continue
             }
-            return returnMatches
+            if rule.conditions.match {
+                returnMatches.append(rule)
+            }
         }
+        return returnMatches
+    }
 }

--- a/Sources/SwiftRuleEngine/RuleEngine.swift
+++ b/Sources/SwiftRuleEngine/RuleEngine.swift
@@ -77,4 +77,19 @@ final public class RuleEngine {
         }
         return nil
     }
+
+    public func evaluateAllRules(_ obj: Any) -> [Rule] {
+            var returnMatches: [Rule] = []
+
+            for rule in rules {
+                var rule = rule
+                guard ((try? rule.conditions.evaluate(obj)) != nil) else {
+                    continue
+                }
+                if rule.conditions.match {
+                    returnMatches.append(rule)
+                }
+            }
+            return returnMatches
+        }
 }

--- a/Sources/SwiftRuleEngine/RuleEngine.swift
+++ b/Sources/SwiftRuleEngine/RuleEngine.swift
@@ -50,10 +50,10 @@ final public class RuleEngine {
     }
     
     public func AppendRulesFromJSON(_ jsonString: Data) throws {
-        if let newRules: [Rule] = try? ruleDecoder.decode([Rule].self, from: jsonString) {
-            self.rules.append(contentsOf: newRules)
-            self.rules.sort { $0.priority > $1.priority }
-        }
+        var newRules: [Rule] = try! ruleDecoder.decode([Rule].self, from: jsonString)
+        
+        self.rules.append(contentsOf: newRules)
+        self.rules.sort { $0.priority > $1.priority }
     }
     
     private func decodeRule(rule: [String: Any]) throws -> Rule {

--- a/Sources/SwiftRuleEngine/RuleEngine.swift
+++ b/Sources/SwiftRuleEngine/RuleEngine.swift
@@ -19,6 +19,12 @@ final public class RuleEngine {
     private let ruleDecoder: RuleDecoder
 
 
+    //Used when we will add additional rules later
+    public convenience init(customOperators: [Operator.Type] = []) throws {
+        let rules: [Rule] = []
+        try self.init(rules: rules, customOperators: customOperators)
+    }
+        
     public convenience init(rules: [String], customOperators: [Operator.Type] = []) throws {
         let ruleDecoder = try RuleDecoder(customOperators)
         let decodedRules = rules.compactMap { dictRule -> Rule? in
@@ -41,6 +47,15 @@ final public class RuleEngine {
         self.ruleDecoder = try RuleDecoder(customOperators)
         self.rules = rules
         self.rules.sort { $0.priority > $1.priority }
+    }
+    
+    public func AppendRulesFromJSON(_ jsonString: String) throws {
+        if let data = jsonString.data(using: .utf8) {
+            if let newRules: [Rule] = try? ruleDecoder.decode([Rule].self, from: data) {
+                self.rules.append(contentsOf: newRules)
+                self.rules.sort { $0.priority > $1.priority }
+            }
+        }
     }
 
     private func decodeRule(rule: [String: Any]) throws -> Rule {

--- a/Sources/SwiftRuleEngine/RuleEngine.swift
+++ b/Sources/SwiftRuleEngine/RuleEngine.swift
@@ -49,12 +49,10 @@ final public class RuleEngine {
         self.rules.sort { $0.priority > $1.priority }
     }
     
-    public func AppendRulesFromJSON(_ jsonString: String) throws {
-        if let data = jsonString.data(using: .utf8) {
-            if let newRules: [Rule] = try? ruleDecoder.decode([Rule].self, from: data) {
-                self.rules.append(contentsOf: newRules)
-                self.rules.sort { $0.priority > $1.priority }
-            }
+    public func AppendRulesFromJSON(_ jsonString: Data) throws {
+        if let newRules: [Rule] = try? ruleDecoder.decode([Rule].self, from: jsonString) {
+            self.rules.append(contentsOf: newRules)
+            self.rules.sort { $0.priority > $1.priority }
         }
     }
 

--- a/SwiftRuleEngine.podspec
+++ b/SwiftRuleEngine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'SwiftRuleEngine'
-  s.version = '1.4.0'
+  s.version = '1.5.0'
   s.license = 'MIT'
   s.summary = 'A rule engine written in Swift where rules are defined in JSON format'
   s.homepage = 'https://github.com/santalvarez/swift-rule-engine'


### PR DESCRIPTION
Added a empty rule engine init so we could make an engine and the call the new AppendRulesFromJSON function to load one or more JSON files into the rules collection.

Added evaluateAllRules which simply iterates through all rules and returns all matches.